### PR TITLE
push on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ jobs:
       - run:
           name: Push images to quay
           command: |
-            docker push quay.io/$CIRCLE_PROJECT_USERNAME/cluster-api-controller:$CIRCLE_SHA1
-            docker push quay.io/$CIRCLE_PROJECT_USERNAME/kubeadm-control-plane-controller:$CIRCLE_SHA1
-            docker push quay.io/$CIRCLE_PROJECT_USERNAME/kubeadm-bootstrap-controller:$CIRCLE_SHA1
+            docker push quay.io/$CIRCLE_PROJECT_USERNAME/cluster-api-controller:${CIRCLE_TAG:-$CIRCLE_SHA1}
+            docker push quay.io/$CIRCLE_PROJECT_USERNAME/kubeadm-control-plane-controller:${CIRCLE_TAG:-$CIRCLE_SHA1}
+            docker push quay.io/$CIRCLE_PROJECT_USERNAME/kubeadm-bootstrap-controller:${CIRCLE_TAG:-$CIRCLE_SHA1}
       - run:
           name: Login to aliyun
           command: |
@@ -28,9 +28,9 @@ jobs:
       - run:
           name: Push image to aliyun
           command: |
-            docker push registry-intl.cn-shanghai.aliyuncs.com/$CIRCLE_PROJECT_USERNAME/cluster-api-controller:$CIRCLE_SHA1
-            docker push registry-intl.cn-shanghai.aliyuncs.com/$CIRCLE_PROJECT_USERNAME/kubeadm-control-plane-controller:$CIRCLE_SHA1
-            docker push registry-intl.cn-shanghai.aliyuncs.com/$CIRCLE_PROJECT_USERNAME/kubeadm-bootstrap-controller:$CIRCLE_SHA1
+            docker push registry-intl.cn-shanghai.aliyuncs.com/$CIRCLE_PROJECT_USERNAME/cluster-api-controller:${CIRCLE_TAG:-$CIRCLE_SHA1}
+            docker push registry-intl.cn-shanghai.aliyuncs.com/$CIRCLE_PROJECT_USERNAME/kubeadm-control-plane-controller:${CIRCLE_TAG:-$CIRCLE_SHA1}
+            docker push registry-intl.cn-shanghai.aliyuncs.com/$CIRCLE_PROJECT_USERNAME/kubeadm-bootstrap-controller:${CIRCLE_TAG:-$CIRCLE_SHA1}
 
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,13 @@ docker-pull-prerequisites:
 	docker pull docker.io/library/golang:1.13.15
 	docker pull gcr.io/distroless/static:latest
 
+# Determine the docker image tag. Try using the tag first or fallback to the commit SHA.
+DOCKER_IMAGE_TAG := $(CIRCLE_TAG)
+ifeq ($(DOCKER_IMAGE_TAG),)
+DOCKER_IMAGE_TAG := $(CIRCLE_SHA1)
+endif
+export DOCKER_IMAGE_TAG
+
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker images for controller managers
 	$(MAKE) ARCH=$(ARCH) docker-build-core
@@ -350,18 +357,18 @@ docker-build: docker-pull-prerequisites ## Build the docker images for controlle
 
 .PHONY: docker-build-core
 docker-build-core: ## Build the docker image for core controller manager
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(CIRCLE_SHA1)
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG_CHINA):$(CIRCLE_SHA1)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(DOCKER_IMAGE_TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG_CHINA):$(DOCKER_IMAGE_TAG)
 
 .PHONY: docker-build-kubeadm-bootstrap
 docker-build-kubeadm-bootstrap: ## Build the docker image for kubeadm bootstrap controller manager
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./bootstrap/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_BOOTSTRAP_CONTROLLER_IMG):$(CIRCLE_SHA1)
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./bootstrap/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_BOOTSTRAP_CONTROLLER_IMG_CHINA):$(CIRCLE_SHA1)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./bootstrap/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_BOOTSTRAP_CONTROLLER_IMG):$(DOCKER_IMAGE_TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./bootstrap/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_BOOTSTRAP_CONTROLLER_IMG_CHINA):$(DOCKER_IMAGE_TAG)
 
 .PHONY: docker-build-kubeadm-control-plane
 docker-build-kubeadm-control-plane: ## Build the docker image for kubeadm control plane controller manager
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./controlplane/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG):$(CIRCLE_SHA1)
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./controlplane/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG_CHINA):$(CIRCLE_SHA1)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./controlplane/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG):$(DOCKER_IMAGE_TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg package=./controlplane/kubeadm --build-arg ldflags="$(LDFLAGS)" . -t $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG_CHINA):$(DOCKER_IMAGE_TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker images


### PR DESCRIPTION
This PR changes the circle CI config to use the git tag name as docker image tag when building.
Based on giantswarm/cluster-api-provider-azure#13