### PR TITLE
Backport changes for bootstrap config reference rotation into v1.4.x branch

### DIFF
--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -605,7 +605,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "existing machinepool, bootstrap data should not change",
+			name: "existing machinepool with config ref, update data secret name",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       builder.TestBootstrapConfigKind,
 				"apiVersion": builder.BootstrapGroupVersion.String(),
@@ -645,11 +645,50 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			expectError: false,
 			expected: func(g *WithT, m *expv1.MachinePool) {
 				g.Expect(m.Status.BootstrapReady).To(BeTrue())
+				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
+			},
+		},
+		{
+			name: "existing machinepool without config ref, do not update data secret name",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": metav1.NamespaceDefault,
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"ready":          true,
+					"dataSecretName": "secret-data",
+				},
+			},
+			machinepool: &expv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bootstrap-test-existing",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: expv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Bootstrap: clusterv1.Bootstrap{
+								DataSecretName: pointer.String("data"),
+							},
+						},
+					},
+				},
+				Status: expv1.MachinePoolStatus{
+					BootstrapReady: true,
+				},
+			},
+			expectError: false,
+			expected: func(g *WithT, m *expv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeTrue())
 				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("data"))
 			},
 		},
 		{
-			name: "existing machinepool, bootstrap provider is to not ready",
+			name: "existing machinepool, bootstrap provider is not ready",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       builder.TestBootstrapConfigKind,
 				"apiVersion": builder.BootstrapGroupVersion.String(),
@@ -683,12 +722,13 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 					},
 				},
 				Status: expv1.MachinePoolStatus{
-					BootstrapReady: true,
+					BootstrapReady: false,
 				},
 			},
-			expectError: false,
+			expectError:  false,
+			expectResult: ctrl.Result{RequeueAfter: externalReadyWait},
 			expected: func(g *WithT, m *expv1.MachinePool) {
-				g.Expect(m.Status.BootstrapReady).To(BeTrue())
+				g.Expect(m.Status.BootstrapReady).To(BeFalse())
 			},
 		},
 	}

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -472,6 +472,173 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(expv1.MachinePoolPhaseDeleting))
 	})
+
+	t.Run("Should keep `Running` when MachinePool bootstrap config is changed to another ready one", func(t *testing.T) {
+		g := NewWithT(t)
+
+		defaultKubeconfigSecret = kubeconfig.GenerateSecret(defaultCluster, kubeconfig.FromEnvTestConfig(env.Config, defaultCluster))
+		machinePool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready.
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Set infra ready.
+		err = unstructured.SetNestedStringSlice(infraConfig.Object, []string{"test://id-1"}, "spec", "providerIDList")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, true, "status", "ready")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, []interface{}{
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.1",
+			},
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.2",
+			},
+		}, "addresses")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, int64(1), "status", "replicas")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Set NodeRef.
+		machinePool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
+
+		// Set replicas to fully reconciled
+		machinePool.Spec.ProviderIDList = []string{"test://id-1"}
+		machinePool.Status.ReadyReplicas = 1
+		machinePool.Status.Replicas = 1
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinePool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
+		}
+
+		res, err := r.reconcile(ctx, defaultCluster, machinePool)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res.Requeue).To(BeFalse())
+
+		r.reconcilePhase(machinePool)
+		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(expv1.MachinePoolPhaseRunning))
+		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
+
+		// Change bootstrap reference.
+		newBootstrapConfig := defaultBootstrap.DeepCopy()
+		newBootstrapConfig.SetName("bootstrap-config2")
+		err = unstructured.SetNestedField(newBootstrapConfig.Object, true, "status", "ready")
+		g.Expect(err).ToNot(HaveOccurred())
+		err = unstructured.SetNestedField(newBootstrapConfig.Object, "secret-data-new", "status", "dataSecretName")
+		g.Expect(err).ToNot(HaveOccurred())
+		err = r.Client.Create(ctx, newBootstrapConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+		machinePool.Spec.Template.Spec.Bootstrap.ConfigRef.Name = newBootstrapConfig.GetName()
+
+		// Reconcile again. The new bootstrap config should be used.
+		res, err = r.reconcile(ctx, defaultCluster, machinePool)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res.Requeue).To(BeFalse())
+
+		r.reconcilePhase(machinePool)
+		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data-new"))
+		g.Expect(machinePool.Status.BootstrapReady).To(BeTrue())
+		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(expv1.MachinePoolPhaseRunning))
+	})
+
+	t.Run("Should keep `Running` when MachinePool bootstrap config is changed to a non-ready one", func(t *testing.T) {
+		g := NewWithT(t)
+
+		defaultKubeconfigSecret = kubeconfig.GenerateSecret(defaultCluster, kubeconfig.FromEnvTestConfig(env.Config, defaultCluster))
+		machinePool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Set infra ready
+		err = unstructured.SetNestedStringSlice(infraConfig.Object, []string{"test://id-1"}, "spec", "providerIDList")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, true, "status", "ready")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, []interface{}{
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.1",
+			},
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.2",
+			},
+		}, "addresses")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, int64(1), "status", "replicas")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Set NodeRef
+		machinePool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
+
+		// Set replicas to fully reconciled
+		machinePool.Spec.ProviderIDList = []string{"test://id-1"}
+		machinePool.Status.ReadyReplicas = 1
+		machinePool.Status.Replicas = 1
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinePool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
+		}
+
+		res, err := r.reconcile(ctx, defaultCluster, machinePool)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res.Requeue).To(BeFalse())
+
+		r.reconcilePhase(machinePool)
+		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(expv1.MachinePoolPhaseRunning))
+		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
+
+		// Change bootstrap reference
+		newBootstrapConfig := defaultBootstrap.DeepCopy()
+		newBootstrapConfig.SetName("bootstrap-config2")
+		err = unstructured.SetNestedField(newBootstrapConfig.Object, false, "status", "ready")
+		g.Expect(err).ToNot(HaveOccurred())
+		// Fill the `dataSecretName` so we can check if the machine pool uses the non-ready secret immediately or,
+		// as it should, not yet
+		err = unstructured.SetNestedField(newBootstrapConfig.Object, "secret-data-new", "status", "dataSecretName")
+		g.Expect(err).ToNot(HaveOccurred())
+		err = r.Client.Create(ctx, newBootstrapConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+		machinePool.Spec.Template.Spec.Bootstrap.ConfigRef.Name = newBootstrapConfig.GetName()
+
+		// Reconcile again. The new bootstrap config should be used
+		res, err = r.reconcile(ctx, defaultCluster, machinePool)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Controller should wait until bootstrap provider reports ready bootstrap config
+		g.Expect(res.Requeue).To(BeFalse())
+
+		r.reconcilePhase(machinePool)
+
+		// The old secret should still be used, as the new bootstrap config is not marked ready
+		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
+		g.Expect(machinePool.Status.BootstrapReady).To(BeFalse())
+
+		// There is no phase defined for "changing to new bootstrap config", so it should still be `Running` the
+		// old configuration
+		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(expv1.MachinePoolPhaseRunning))
+	})
 }
 
 func TestReconcileMachinePoolBootstrap(t *testing.T) {


### PR DESCRIPTION
Backports https://github.com/kubernetes-sigs/cluster-api/pull/9616 (not merged upstream, but close) and https://github.com/kubernetes-sigs/cluster-api/pull/8667 (merged upstream but not part of 1.4.x). This is absolutely required for https://github.com/giantswarm/roadmap/issues/2217 unless we switch to CAPI v1.5.x _now_.

I had already successfully tested this together with https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4619 on a real management+workload cluster.