### PR TITLE
Push to Azure registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       image: "ubuntu-2204:2022.10.2"
     environment:
       ALL_ARCH: "amd64 arm64"
+      REGISTRY_AZURE: gsoci.azurecr.io/giantswarm
       REGISTRY_QUAY: quay.io/giantswarm
       REGISTRY_CHINA: giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm
 
@@ -15,6 +16,7 @@ jobs:
     resource_class: xlarge # building several Docker images for multiple architectures is otherwise slow
     steps:
       - checkout
+
       - run:
           name: Build the CAPI docker images
           command: |
@@ -22,7 +24,7 @@ jobs:
             export DOCKER_BUILDKIT=1
             export BUILDKIT_PROGRESS=plain
 
-            for registry in $REGISTRY_QUAY $REGISTRY_CHINA; do
+            for registry in $REGISTRY_AZURE $REGISTRY_QUAY $REGISTRY_CHINA; do
               make docker-build-all ALL_ARCH="$ALL_ARCH" ALL_DOCKER_BUILD="$ALL_DOCKER_BUILD" TAG=$CIRCLE_SHA1 REGISTRY=$registry
 
               if [ -n "$CIRCLE_TAG" ]; then
@@ -32,6 +34,19 @@ jobs:
             done
 
             docker images
+
+      - run:
+          name: Push to Azure
+          command: |
+            docker login --username $ACR_GSOCI_USERNAME --password $ACR_GSOCI_PASSWORD "${REGISTRY_AZURE%%/*}"
+
+            make docker-push-all ALL_ARCH="$ALL_ARCH" ALL_DOCKER_BUILD="$ALL_DOCKER_BUILD" TAG=$CIRCLE_SHA1 REGISTRY=$REGISTRY_AZURE
+
+            if [ -n "$CIRCLE_TAG" ]; then
+              echo "Pushing tag $CIRCLE_TAG"
+              make docker-push-all ALL_ARCH="$ALL_ARCH" ALL_DOCKER_BUILD="$ALL_DOCKER_BUILD" TAG="$CIRCLE_TAG" REGISTRY=$REGISTRY_AZURE
+            fi
+
       - run:
           name: Push to quay
           command: |


### PR DESCRIPTION
Basically the same as https://github.com/giantswarm/cluster-api-provider-aws/pull/581/files. The app was already changed to the Azure registry, so some clusters currently fail to pull the image because it's not on Azure.